### PR TITLE
add graphql snippets for image sharp, contentful, and datocms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Markdown snippets for GatsbyJS. [vscode-gatsby-snippets](https://marketplace.vis
 
 ## Release Notes
 
+### 1.1.0
+
+Added GatsbyJS graphql image fragment snippets.
+
 ### 1.0.3
 
 Added list of shortcuts.
@@ -24,23 +28,69 @@ Initial release.
 
 ---
 
-## Gatsby snippets shortcuts
+## Gatsby Markdown snippets shortcuts
 
 Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (OSX) to see a list of Markdown snippets
 
-- `ga` - creates a new article
-- `gp` - creates a new page
+Snippet | Output
+--- | ---
+`ga` | creates a new article
+`gp` | creates a new page
 
-## Working with Markdown
+### Working with Markdown
 
 Here are some useful editor keyboard shortcuts:
 
 - Split the editor (`Cmd+\` on OSX or `Ctrl+\` on Windows and Linux)
 - Toggle preview (`Shift+CMD+V` on OSX or `Shift+Ctrl+V` on Windows and Linux)
 
-### For more information
+### More information
 
 - [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
 - [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
+
+## Gatsby Graphql snippets shortcuts
+
+These snippets require embedded graphql syntax support. You can enable support by installing [gatsby-extension-pack](https://marketplace.visualstudio.com/items?itemName=nickytonline.gatsby-extension-pack).
+### Gatsby Image sharp snippets
+
+Snippet | Output
+--- | ---
+`gfi` | `...GatsbyImageSharpFixed`
+`gfino` | `...GatsbyImageSharpFixed_noBase64`
+`gfisvg` | `...GatsbyImageSharpFixed_tracedSVG`
+`gfiwp` | `...GatsbyImageSharpFixed_withWebp`
+`gfiwpno` | `...GatsbyImageSharpFixed_withWebp_noBase64`
+`gfiwpsvg` | `...GatsbyImageSharpFixed_withWebp_tracedSVG`
+`gfl` | `...GatsbyImageSharpFluid`
+`gflno` | `...GatsbyImageSharpFluid_noBase64`
+`gflsvg` | `...GatsbyImageSharpFluid_tracedSVG`
+`gflwp` | `...GatsbyImageSharpFluid_withWebp`
+`gflwpno` |`...GatsbyImageSharpFluid_withWebp_noBase64`
+`gflwpsvg` | `...GatsbyImageSharpFluid_withWebp_tracedSVG`
+
+### Gatsby Source Contentful snippets
+
+Snippet | Output
+--- | ---
+`gscfi` | `...GatsbyContentfulFixed`
+`gscfino` | `...GatsbyContentfulFixed_noBase64`
+`gscfisvg` | `...GatsbyContentfulFixed_tracedSVG`
+`gscfiwp` | `...GatsbyContentfulFixed_withWebp`
+`gscfiwpno` | `...GatsbyContentfulFixed_withWebp_noBase64`
+`gscfl` | `...GatsbyContentfulFluid`
+`gscflno` | `...GatsbyContentfulFluid_noBase64`
+`gscflsvg` | `...GatsbyContentfulFluid_tracedSVG`
+`gscflwp` | `...GatsbyContentfulFluid_withWebp`
+`gscflwpno` | `...GatsbyContentfulFluid_withWebp_noBase64`
+
+### Gatsby Source DatoCMS snippets
+
+Snippet | Output
+--- | ---
+`gsdfi` | `...GatsbyDatoCmsFixed`
+`gsdfino` | `...GatsbyDatoCmsFixed_noBase64`
+`gsdfl` | `...GatsbyDatoCmsFluid`
+`gsdflno` | `...GatsbyDatoCmsFluid_noBase64`
 
 **Enjoy!**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-gatsby-snippets",
   "displayName": "vscode-gatsby-snippets",
   "description": "Visual Studio Code code snippets for use with the GatsbyJS static site generator for React.",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "scripts": {
     "precommit": "lint-staged"
   },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,18 @@
       {
         "language": "typescriptreact",
         "path": "./snippets/react-snippets.json"
+      },
+      {
+        "language": "graphql",
+        "path": "./snippets/gatsby-image-sharp-graphql-fragments.json"
+      },
+      {
+        "language": "graphql",
+        "path": "./snippets/gatsby-source-contentful-graphql-fragments.json"
+      },
+      {
+        "language": "graphql",
+        "path": "./snippets/gatsby-source-datocms-graphql-fragments.json"
       }
     ]
   },

--- a/snippets/gatsby-image-sharp-graphql-fragments.json
+++ b/snippets/gatsby-image-sharp-graphql-fragments.json
@@ -70,7 +70,7 @@
     "description": "gatsby-transformer-sharp graphql fragment"
   },
   "gatsby-image-sharp fluid / with Webp / no base64 fragment": {
-    "prefix": "gflwbno",
+    "prefix": "gflwpno",
     "body": [
       "...GatsbyImageSharpFluid_withWebp_noBase64"
     ],

--- a/snippets/gatsby-image-sharp-graphql-fragments.json
+++ b/snippets/gatsby-image-sharp-graphql-fragments.json
@@ -1,0 +1,86 @@
+{
+  "gatsby-image-sharp fixed fragment": {
+    "prefix": "gfi",
+    "body": [
+      "...GatsbyImageSharpFixed"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fixed / no base64 fragment": {
+    "prefix": "gfino",
+    "body": [
+      "...GatsbyImageSharpFixed_noBase64"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fixed / traced SVG fragment": {
+    "prefix": "gfisvg",
+    "body": [
+      "...GatsbyImageSharpFixed_tracedSVG"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fixed / with Webp fragment": {
+    "prefix": "gfiwp",
+    "body": [
+      "...GatsbyImageSharpFixed_withWebp"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fixed / Webp / no base64 fragment": {
+    "prefix": "gfiwpno",
+    "body": [
+      "...GatsbyImageSharpFixed_withWebp_noBase64"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fixed / Webp / traced SVG fragment": {
+    "prefix": "gfiwpsvg",
+    "body": [
+      "...GatsbyImageSharpFixed_withWebp_tracedSVG"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fluid fragment": {
+    "prefix": "gfl",
+    "body": [
+      "...GatsbyImageSharpFluid"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fluid / no base64 fragment": {
+    "prefix": "gflno",
+    "body": [
+      "...GatsbyImageSharpFluid_noBase64"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fluid / traced SVG fragment": {
+    "prefix": "gflsvg",
+    "body": [
+      "...GatsbyImageSharpFluid_tracedSVG"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fluid / with Webp fragment": {
+    "prefix": "gflwp",
+    "body": [
+      "...GatsbyImageSharpFluid_withWebp"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fluid / with Webp / no base64 fragment": {
+    "prefix": "gflwbno",
+    "body": [
+      "...GatsbyImageSharpFluid_withWebp_noBase64"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  },
+  "gatsby-image-sharp fluid / with Webp / traced SVG fragment": {
+    "prefix": "gflwpsvg",
+    "body": [
+      "...GatsbyImageSharpFluid_withWebp_tracedSVG"
+    ],
+    "description": "gatsby-transformer-sharp graphql fragment"
+  }
+}

--- a/snippets/gatsby-source-contentful-graphql-fragments.json
+++ b/snippets/gatsby-source-contentful-graphql-fragments.json
@@ -1,0 +1,72 @@
+{
+    "gatsby-source-contentful fixed fragment": {
+      "prefix": "gscfi",
+      "body": [
+        "...GatsbyContentfulFixed"
+      ],
+      "description": "gatsby-source-contentful graphql fragment"
+    },
+    "gatsby-source-contentful fixed / no base64 fragment": {
+      "prefix": "gscfino",
+      "body": [
+        "...GatsbyContentfulFixed_noBase64"
+      ],
+      "description": "gatsby-source-contentful graphql fragment"
+    },
+    "gatsby-source-contentful fixed / traced SVG fragment": {
+      "prefix": "gscfisvg",
+      "body": [
+        "...GatsbyContentfulFixed_tracedSVG"
+      ],
+      "description": "gatsby-source-contentful graphql fragment"
+    },
+    "gatsby-source-contentful fixed / with Webp fragment": {
+      "prefix": "gscfiwp",
+      "body": [
+        "...GatsbyContentfulFixed_withWebp"
+      ],
+      "description": "gatsby-source-contentful graphql fragment"
+    },
+    "gatsby-source-contentful fixed / with Webp / no base64 fragment": {
+      "prefix": "gscfiwpno",
+      "body": [
+        "...GatsbyContentfulFixed_withWebp_noBase64"
+      ],
+      "description": "gatsby-source-contentful graphql fragment"
+    },
+    "gatsby-source-contentful fluid fragment": {
+      "prefix": "gscfl",
+      "body": [
+        "...GatsbyContentfulFluid"
+      ],
+      "description": "gatsby-source-contentful graphql fragment"
+    },
+    "gatsby-source-contentful fluid / no base64 fragment": {
+      "prefix": "gscflno",
+      "body": [
+        "...GatsbyContentfulFluid_noBase64"
+      ],
+      "description": "gatsby-source-contentful graphql fragment"
+    },
+    "gatsby-source-contentful fluid / traced SVG fragment": {
+      "prefix": "gscflsvg",
+      "body": [
+        "...GatsbyContentfulFluid_tracedSVG"
+      ],
+      "description": "gatsby-source-contentful graphql fragment"
+    },
+    "gatsby-source-contentful fluid / with Webp fragment": {
+      "prefix": "gscflwp",
+      "body": [
+        "...GatsbyContentfulFluid_withWebp"
+      ],
+      "description": "gatsby-source-contentful graphql fragment"
+    },
+    "gatsby-source-contentful fluid / with Webp / no base64 fragment": {
+      "prefix": "gscflwpno",
+      "body": [
+        "...GatsbyContentfulFluid_withWebp_noBase64"
+      ],
+      "description": "gatsby-source-contentful graphql fragment"
+    }
+}

--- a/snippets/gatsby-source-datocms-graphql-fragments.json
+++ b/snippets/gatsby-source-datocms-graphql-fragments.json
@@ -1,0 +1,30 @@
+{
+      "gatsby-source-datocms fixed fragment": {
+        "prefix": "gsdfi",
+        "body": [
+          "...GatsbyDatoCmsFixed"
+        ],
+        "description": "gatsby-source-datocms graphql fragment"
+      },
+      "gatsby-source-datocms fixed / no base64 fragment": {
+        "prefix": "gsdfino",
+        "body": [
+          "...GatsbyDatoCmsFixed_noBase64"
+        ],
+        "description": "gatsby-source-datocms graphql fragment"
+      },
+      "gatsby-source-datocms fluid fragment": {
+        "prefix": "gsdfl",
+        "body": [
+          "...GatsbyDatoCmsFluid"
+        ],
+        "description": "gatsby-source-datocms graphql fragment"
+      },
+      "gatsby-source-datocms fluid / no base64 fragment": {
+        "prefix": "gsdflno",
+        "body": [
+          "...GatsbyDatoCmsFluid_noBase64"
+        ],
+        "description": "gatsby-source-datocms graphql fragment"
+      }
+}


### PR DESCRIPTION
Hey, this is related to #6 

I've added all the image sharp fragments and from my testing they look great!

There is a single issue which is that I tested this with all vscode extensions disabled  and I could only get the snippets to show up with [vscode-graphql](https://github.com/prisma/vscode-graphql) installed.

That extension adds support for graphql tagged template literals in javascript. I think adding support for that isn't the job of this extension though so these fragment snippets would require the user to have support added externally. What do you think?